### PR TITLE
Persist region selection in session storage

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -34,49 +34,49 @@
     <br>    
     <div class="poke-option">
       <div class="region-option">
-        <input type="checkbox" [(ngModel)]="kanto"><label>Kanto</label>
+        <input type="checkbox" [(ngModel)]="kanto" (ngModelChange)="saveRegionConfig()"><label>Kanto</label>
       </div>
     </div>
     <br>    
     <div class="poke-option">
       <div class="region-option">
-        <input type="checkbox" [(ngModel)]="johto"><label>Johto</label>
+        <input type="checkbox" [(ngModel)]="johto" (ngModelChange)="saveRegionConfig()"><label>Johto</label>
       </div>
     </div>
     <br>    
     <div class="poke-option">
       <div class="region-option">
-        <input type="checkbox" [(ngModel)]="hoenn"><label>Hoenn</label>
+        <input type="checkbox" [(ngModel)]="hoenn" (ngModelChange)="saveRegionConfig()"><label>Hoenn</label>
       </div>
     </div>
     <br>    
     <div class="poke-option">
       <div class="region-option">
-        <input type="checkbox" [(ngModel)]="sinnoh"><label>Sinnoh</label>
+        <input type="checkbox" [(ngModel)]="sinnoh" (ngModelChange)="saveRegionConfig()"><label>Sinnoh</label>
       </div>
     </div>
     <br>    
     <div class="poke-option">
       <div class="region-option">
-        <input type="checkbox" [(ngModel)]="unova"><label>Unova</label>
+        <input type="checkbox" [(ngModel)]="unova" (ngModelChange)="saveRegionConfig()"><label>Unova</label>
       </div>
     </div>
     <br>    
     <div class="poke-option">
       <div class="region-option">
-        <input type="checkbox" [(ngModel)]="kalos"><label>Kalos</label>
+        <input type="checkbox" [(ngModel)]="kalos" (ngModelChange)="saveRegionConfig()"><label>Kalos</label>
       </div>
     </div>
     <br>    
     <div class="poke-option">
       <div class="region-option">
-        <input type="checkbox" [(ngModel)]="alola"><label>Alola</label>
+        <input type="checkbox" [(ngModel)]="alola" (ngModelChange)="saveRegionConfig()"><label>Alola</label>
       </div>
     </div>
     <br>    
     <div class="poke-option">
       <div class="region-option">
-        <input type="checkbox" [(ngModel)]="paldea"><label>Paldea</label>
+        <input type="checkbox" [(ngModel)]="paldea" (ngModelChange)="saveRegionConfig()"><label>Paldea</label>
       </div>
     </div>
   </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,6 +12,7 @@ export class AppComponent {
   title = 'whosThatPokemon';
 
   constructor(private contactService: PokemonService, private sunsaleService: SunSaleService) {
+    this.loadRegionConfig();
     this.gerarLista();
    }
 
@@ -31,17 +32,47 @@ export class AppComponent {
   subscription = new Subscription();
   total = 0;
   kanto = true;
-  johto = true;
-  hoenn = true;
-  sinnoh = true;
-  unova = true;
-  kalos = true;
-  alola = true;
-  paldea = true;
+  johto = false;
+  hoenn = false;
+  sinnoh = false;
+  unova = false;
+  kalos = false;
+  alola = false;
+  paldea = false;
   nome = "";
 
   timer$ = interval(1000);
   seconds = 0;
+
+  saveRegionConfig() {
+    sessionStorage.setItem('regionConfig', JSON.stringify({
+      kanto: this.kanto,
+      johto: this.johto,
+      hoenn: this.hoenn,
+      sinnoh: this.sinnoh,
+      unova: this.unova,
+      kalos: this.kalos,
+      alola: this.alola,
+      paldea: this.paldea
+    }));
+  }
+
+  loadRegionConfig() {
+    const configString = sessionStorage.getItem('regionConfig');
+    if (configString) {
+      const config = JSON.parse(configString);
+      this.kanto = config.kanto;
+      this.johto = config.johto;
+      this.hoenn = config.hoenn;
+      this.sinnoh = config.sinnoh;
+      this.unova = config.unova;
+      this.kalos = config.kalos;
+      this.alola = config.alola;
+      this.paldea = config.paldea;
+    } else {
+      this.saveRegionConfig();
+    }
+  }
 
   async start() {
     this.subscription = this.timer$.subscribe(async () => {


### PR DESCRIPTION
## Summary
- Default region selection to Kanto only and persist choices in session storage
- Update region checkboxes to save settings on change

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3a6fecfc832cb0febdf317e1e881